### PR TITLE
feat(stagefit): wire lead capture, Kit tags, Turnstile fix, formatting

### DIFF
--- a/src/app/actions/newsletter.ts
+++ b/src/app/actions/newsletter.ts
@@ -26,13 +26,21 @@ const ALLOWED_CUSTOM_FIELDS = new Set([
 	"trigger_event",
 ]);
 
-const ARCHITECT_BRIEF_TAG_ID = 19804765;
+const TAG_IDS: Record<string, number> = {
+	"architect-brief": 19804765,
+	"stagefit-lead": 19804766,
+	"source-footer": 19804767,
+	"source-blog": 19804768,
+	"source-stagefit-quiz": 19804769,
+};
 
 const SOURCE_TAG_MAP: Record<string, string> = {
 	footer: "source-footer",
 	"blog-sidebar": "source-blog",
 	"stage-fit-quiz-v2": "source-stagefit-quiz",
 };
+
+const TURNSTILE_EXEMPT_SOURCES = new Set(["stage-fit-quiz-v2"]);
 
 const newsletterSchema = z.object({
 	email: z.string().email("Please enter a valid email address"),
@@ -99,7 +107,8 @@ export async function subscribeToNewsletter(data: unknown): Promise<NewsletterFo
 
 	const env = await getEnv();
 
-	if (env.NODE_ENV === "production" || turnstileToken) {
+	const turnstileExempt = TURNSTILE_EXEMPT_SOURCES.has(source);
+	if (!turnstileExempt && (env.NODE_ENV === "production" || turnstileToken)) {
 		if (!turnstileToken) {
 			return { success: false, error: "Bot check required. Please try again." };
 		}
@@ -141,13 +150,21 @@ export async function subscribeToNewsletter(data: unknown): Promise<NewsletterFo
 			const subscriber = resData.subscriber as Record<string, unknown> | undefined;
 			const isExisting = subscriber?.created_at !== subscriber?.updated_at;
 
-			await dependencies
-				.fetch(`https://api.kit.com/v4/tags/${ARCHITECT_BRIEF_TAG_ID}/subscribers`, {
-					method: "POST",
-					headers: { "X-Kit-Api-Key": apiKey, "Content-Type": "application/json" },
-					body: JSON.stringify({ email_address: email }),
-				})
-				.catch(() => {});
+			const tagIdsToApply = [TAG_IDS["architect-brief"]];
+			if (sourceTag && TAG_IDS[sourceTag]) tagIdsToApply.push(TAG_IDS[sourceTag]);
+			if (customFields?.stagefit_zone) tagIdsToApply.push(TAG_IDS["stagefit-lead"]);
+
+			await Promise.all(
+				tagIdsToApply.map((tagId) =>
+					dependencies
+						.fetch(`https://api.kit.com/v4/tags/${tagId}/subscribers`, {
+							method: "POST",
+							headers: { "X-Kit-Api-Key": apiKey, "Content-Type": "application/json" },
+							body: JSON.stringify({ email_address: email }),
+						})
+						.catch(() => {})
+				)
+			);
 
 			return { success: true, existingSubscriber: isExisting };
 		}

--- a/src/components/tools/stagefit/StageFitDiagnostic.tsx
+++ b/src/components/tools/stagefit/StageFitDiagnostic.tsx
@@ -2,8 +2,11 @@
 
 import { useState } from "react";
 
+import { submitStageFitLead } from "@/app/actions/stagefit-lead";
+import { applyModifiers, getStageBaseline } from "@/data/saas-stagefit/baseline-matrix";
 import { calculateStageFit } from "@/data/saas-stagefit/calculate";
 
+import { LeadCapture } from "./LeadCapture";
 import { ContextQuestions } from "./phases/ContextQuestions";
 import { DiagnosisScreen } from "./phases/DiagnosisScreen";
 import { Interstitial } from "./phases/Interstitial";
@@ -25,6 +28,7 @@ export function StageFitDiagnostic() {
 	const [contextAnswers, setContextAnswers] = useState<Record<string, string>>({});
 	const [result, setResult] = useState<StageFitResult | null>(null);
 	const [input, setInput] = useState<StageFitInput | null>(null);
+	const [leadCaptured, setLeadCaptured] = useState(false);
 
 	if (phase === "intro") {
 		return <IntroScreen onStart={() => setPhase("context")} />;
@@ -42,6 +46,14 @@ export function StageFitDiagnostic() {
 	}
 
 	const persona = (contextAnswers["q1-role"] ?? "cto") as Persona;
+	const revenueStage = Number(contextAnswers["q3-revenue"] ?? "0") as StageFitInput["revenueStage"];
+	const customerType = (contextAnswers["q2-customer-type"] ??
+		"b2b-smb") as StageFitInput["customerType"];
+	const triggerEvent = (contextAnswers["q4-trigger"] ?? "none") as StageFitInput["triggerEvent"];
+	const compliance = [
+		(contextAnswers["q5-compliance"] ?? "none") as StageFitInput["compliance"][0],
+	];
+	const teamSize = Number(contextAnswers["q6-team-size"] ?? "0") as StageFitInput["teamSize"];
 
 	if (phase === "interstitial") {
 		return (
@@ -55,22 +67,26 @@ export function StageFitDiagnostic() {
 	}
 
 	if (phase === "tech") {
+		const baseline = applyModifiers(
+			getStageBaseline(revenueStage),
+			customerType,
+			compliance,
+			teamSize,
+			triggerEvent
+		);
+
 		return (
 			<TechQuestions
 				persona={persona}
+				baseline={baseline}
 				onComplete={(techAnswers: Record<TechDimension, TechScore>) => {
 					const stageFitInput: StageFitInput = {
 						persona,
-						customerType: (contextAnswers["q2-customer-type"] ??
-							"b2b-smb") as StageFitInput["customerType"],
-						revenueStage: Number(
-							contextAnswers["q3-revenue"] ?? "0"
-						) as StageFitInput["revenueStage"],
-						triggerEvent: (contextAnswers["q4-trigger"] ?? "none") as StageFitInput["triggerEvent"],
-						compliance: [
-							(contextAnswers["q5-compliance"] ?? "none") as StageFitInput["compliance"][0],
-						],
-						teamSize: Number(contextAnswers["q6-team-size"] ?? "0") as StageFitInput["teamSize"],
+						customerType,
+						revenueStage,
+						triggerEvent,
+						compliance,
+						teamSize,
 						techAnswers,
 					};
 					setInput(stageFitInput);
@@ -82,7 +98,23 @@ export function StageFitDiagnostic() {
 	}
 
 	if (phase === "diagnosis" && result && input) {
-		return <DiagnosisScreen input={input} result={result} />;
+		return (
+			<>
+				<DiagnosisScreen input={input} result={result} />
+				{!leadCaptured ? (
+					<LeadCapture
+						zone={result.zone}
+						result={result}
+						onSuccess={() => setLeadCaptured(true)}
+						onSubmitEmail={async (email) => submitStageFitLead({ email, answers: input })}
+					/>
+				) : (
+					<p className="text-cyber-lime mt-4 font-mono text-sm">
+						Check your inbox for your personalized remediation plan.
+					</p>
+				)}
+			</>
+		);
 	}
 
 	return null;

--- a/src/components/tools/stagefit/phases/DiagnosisScreen.tsx
+++ b/src/components/tools/stagefit/phases/DiagnosisScreen.tsx
@@ -14,11 +14,17 @@ export function DiagnosisScreen({ input, result }: DiagnosisScreenProps) {
 	const ctaHref = `/contact?${ctaParams.toString()}`;
 
 	return (
-		<section>
-			<h2>{copy.diagnosis}</h2>
-			<p>{copy.symptoms}</p>
-			<p>{copy.prognosisVelocity}</p>
-			<a href={ctaHref}>{copy.prescriptionCta}</a>
+		<section className="mx-auto max-w-2xl">
+			<p className="text-cyber-lime mb-2 font-mono text-xs tracking-wider uppercase">Diagnosis</p>
+			<h2 className="text-mist-white mb-4 font-mono text-2xl tracking-tight">{copy.diagnosis}</h2>
+			<p className="text-slate-text mb-4 text-base leading-relaxed">{copy.symptoms}</p>
+			<p className="text-slate-text mb-6 text-base leading-relaxed">{copy.prognosisVelocity}</p>
+			<a
+				href={ctaHref}
+				className="border-cyber-lime bg-cyber-lime/10 text-cyber-lime hover:bg-cyber-lime/20 focus-visible:ring-cyber-lime inline-block border px-6 py-3 font-mono text-sm tracking-tight transition-colors focus:outline-none focus-visible:ring-2"
+			>
+				{copy.prescriptionCta}
+			</a>
 		</section>
 	);
 }

--- a/src/components/tools/stagefit/phases/TechQuestions.tsx
+++ b/src/components/tools/stagefit/phases/TechQuestions.tsx
@@ -1,44 +1,122 @@
 "use client";
 
+import { m } from "framer-motion";
 import { useState } from "react";
 
 import { QUIZ_QUESTIONS } from "@/data/saas-stagefit/questions";
+import { fadeInUp, snappySpringTransition, staggerContainer } from "@/lib/motion-constants";
 
-import type { Persona, TechDimension, TechQuestion, TechScore } from "@/data/saas-stagefit/types";
+import { HotTruncate } from "./HotTruncate";
+
+import type { TechBaseline } from "@/data/saas-stagefit/baseline-matrix";
+import type {
+	Persona,
+	TechDimension,
+	TechQuestion,
+	TechScore,
+	Zone,
+} from "@/data/saas-stagefit/types";
 
 const TECH_QS = QUIZ_QUESTIONS.filter((q): q is TechQuestion => q.kind === "tech");
+const HOT_TRUNCATE_THRESHOLD = 3;
 
 interface TechQuestionsProps {
 	persona: Persona;
 	onComplete: (answers: Record<TechDimension, TechScore>) => void;
+	baseline?: TechBaseline;
 }
 
-export function TechQuestions({ persona, onComplete }: TechQuestionsProps) {
+export function TechQuestions({ persona, onComplete, baseline }: TechQuestionsProps) {
+	const [index, setIndex] = useState(0);
 	const [answers, setAnswers] = useState<Partial<Record<TechDimension, TechScore>>>({});
+	const [hotTruncateDismissed, setHotTruncateDismissed] = useState(false);
 
 	function handleSelect(dim: TechDimension, score: TechScore) {
 		const next = { ...answers, [dim]: score };
 		setAnswers(next);
 		if (Object.keys(next).length === TECH_QS.length) {
 			onComplete(next as Record<TechDimension, TechScore>);
+			return;
+		}
+		if (index < TECH_QS.length - 1) {
+			setIndex(index + 1);
 		}
 	}
 
-	const questionText = (q: TechQuestion) =>
-		persona === "founder" ? q.questionFounder : q.questionCto;
+	const question = TECH_QS[index];
+	const questionText = persona === "founder" ? question.questionFounder : question.questionCto;
+
+	const answeredCount = Object.keys(answers).length;
+	const showHotTruncate =
+		baseline && answeredCount >= HOT_TRUNCATE_THRESHOLD && !hotTruncateDismissed;
+
+	let hotTruncateData: { misalignedCount: number; leaningZone: Zone } | null = null;
+	if (showHotTruncate && baseline) {
+		const dims = Object.entries(answers) as [TechDimension, TechScore][];
+		const misaligned = dims.filter(([dim, score]) => Math.abs(score - baseline[dim]) >= 1);
+		const totalDelta = dims.reduce((sum, [dim, score]) => sum + (score - baseline[dim]), 0);
+		hotTruncateData = {
+			misalignedCount: misaligned.length,
+			leaningZone: totalDelta >= 0 ? "over-built" : "under-built",
+		};
+	}
+
+	const CONTEXT_QUESTION_COUNT = 6;
+	const totalQuestions = TECH_QS.length + CONTEXT_QUESTION_COUNT;
+	const currentNumber = index + 1 + CONTEXT_QUESTION_COUNT;
 
 	return (
-		<section>
-			{TECH_QS.map((q) => (
-				<div key={q.id}>
-					<span>{questionText(q)}</span>
-					{q.options.map((opt) => (
-						<button key={opt.score} onClick={() => handleSelect(q.dimension, opt.score)}>
+		<section className="mx-auto max-w-2xl">
+			<div className="mb-6 flex items-center justify-between">
+				<span className="text-slate-text font-mono text-xs">
+					{currentNumber} of {totalQuestions}
+				</span>
+				<span className="text-slate-text font-mono text-xs">{question.category}</span>
+			</div>
+
+			<m.div
+				key={question.id}
+				initial={{ opacity: 0, x: 20 }}
+				animate={{ opacity: 1, x: 0 }}
+				transition={snappySpringTransition}
+			>
+				<h3 className="text-mist-white mb-6 font-mono text-lg tracking-tight">{questionText}</h3>
+
+				<m.div
+					variants={staggerContainer}
+					initial="hidden"
+					animate="visible"
+					className="flex flex-col gap-3"
+				>
+					{question.options.map((opt) => (
+						<m.button
+							key={opt.score}
+							variants={fadeInUp}
+							onClick={() => handleSelect(question.dimension, opt.score)}
+							className="text-slate-text hover:text-mist-white hover:border-cyber-lime/40 focus-visible:ring-cyber-lime border border-white/10 px-5 py-3 text-left font-mono text-sm transition-colors focus:outline-none focus-visible:ring-2"
+						>
 							{opt.label}
-						</button>
+						</m.button>
 					))}
+				</m.div>
+			</m.div>
+
+			{hotTruncateData && (
+				<HotTruncate
+					misalignedCount={hotTruncateData.misalignedCount}
+					leaningZone={hotTruncateData.leaningZone}
+					onContinue={() => setHotTruncateDismissed(true)}
+				/>
+			)}
+
+			<div className="mt-8">
+				<div className="h-1 w-full border border-white/5">
+					<div
+						className="bg-cyber-lime/40 h-full transition-all"
+						style={{ width: `${(currentNumber / totalQuestions) * 100}%` }}
+					/>
 				</div>
-			))}
+			</div>
 		</section>
 	);
 }

--- a/tests/actions/newsletter.test.ts
+++ b/tests/actions/newsletter.test.ts
@@ -213,7 +213,7 @@ describe("subscribeToNewsletter", () => {
 		it("should send correct Kit payload", async () => {
 			await subscribeToNewsletter({ email: "payload@example.com", source: "footer" });
 
-			expect(mockFetch).toHaveBeenCalledTimes(2);
+			expect(mockFetch.mock.calls.length).toBeGreaterThanOrEqual(2);
 			const [url, options] = mockFetch.mock.calls[0] as [string, RequestInit];
 			expect(url).toBe("https://api.kit.com/v4/subscribers");
 			expect(options.method).toBe("POST");
@@ -222,9 +222,12 @@ describe("subscribeToNewsletter", () => {
 			const body = JSON.parse(options.body as string) as Record<string, unknown>;
 			expect(body.email_address).toBe("payload@example.com");
 
-			const tagCall = mockFetch.mock.calls[1] as [string, RequestInit];
-			expect(tagCall[0]).toContain("/tags/");
-			expect(tagCall[0]).toContain("/subscribers");
+			const tagCalls = mockFetch.mock.calls.filter(
+				(c) => typeof c[0] === "string" && (c[0] as string).includes("/tags/")
+			);
+			expect(tagCalls.length).toBeGreaterThan(0);
+			expect(tagCalls[0][0]).toContain("/tags/");
+			expect(tagCalls[0][0]).toContain("/subscribers");
 		});
 
 		it("should include AbortSignal with 8-second timeout", async () => {
@@ -277,8 +280,10 @@ describe("subscribeToNewsletter", () => {
 });
 
 describe("Tag application", () => {
-	it("should apply architect-brief tag via separate API call after subscribe", async () => {
-		const mockFetchLocal = vi.fn();
+	let mockFetchLocal: ReturnType<typeof vi.fn> & typeof globalThis.fetch;
+
+	beforeEach(async () => {
+		mockFetchLocal = vi.fn() as typeof mockFetchLocal;
 		mockFetchLocal.mockResolvedValueOnce({
 			ok: true,
 			json: () =>
@@ -287,9 +292,14 @@ describe("Tag application", () => {
 				}),
 		});
 		mockFetchLocal.mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
-
 		await __setDependencies({ fetch: mockFetchLocal });
+	});
 
+	afterEach(async () => {
+		await __resetDependencies();
+	});
+
+	it("should apply architect-brief tag via separate API call after subscribe", async () => {
 		await subscribeToNewsletter({ email: "tag-test@example.com", source: "footer" });
 
 		const tagCalls = mockFetchLocal.mock.calls.filter(
@@ -298,5 +308,104 @@ describe("Tag application", () => {
 		expect(tagCalls.length).toBeGreaterThan(0);
 		expect(tagCalls[0][0]).toContain("/tags/");
 		expect(tagCalls[0][0]).toContain("/subscribers");
+	});
+
+	it("should apply source-blog tag for blog-sidebar source", async () => {
+		await subscribeToNewsletter({ email: "tag-test@example.com", source: "blog-sidebar" });
+
+		const tagCalls = mockFetchLocal.mock.calls.filter(
+			(c) => typeof c[0] === "string" && (c[0] as string).includes("/tags/")
+		);
+		const tagUrls = tagCalls.map((c) => c[0] as string);
+		expect(tagUrls).toContainEqual(expect.stringContaining("/tags/19804768/subscribers"));
+	});
+
+	it("should apply stagefit-lead tag when stagefit_zone is present", async () => {
+		await subscribeToNewsletter({
+			email: "tag-test@example.com",
+			source: "stage-fit-quiz-v2",
+			customFields: { stagefit_zone: "under-built" },
+		});
+
+		const tagCalls = mockFetchLocal.mock.calls.filter(
+			(c) => typeof c[0] === "string" && (c[0] as string).includes("/tags/")
+		);
+		const tagUrls = tagCalls.map((c) => c[0] as string);
+		expect(tagUrls).toContainEqual(expect.stringContaining("/tags/19804766/subscribers"));
+	});
+
+	it("should apply source-stagefit-quiz tag for quiz source", async () => {
+		await subscribeToNewsletter({
+			email: "tag-test@example.com",
+			source: "stage-fit-quiz-v2",
+			customFields: { stagefit_zone: "over-built" },
+		});
+
+		const tagCalls = mockFetchLocal.mock.calls.filter(
+			(c) => typeof c[0] === "string" && (c[0] as string).includes("/tags/")
+		);
+		const tagUrls = tagCalls.map((c) => c[0] as string);
+		expect(tagUrls).toContainEqual(expect.stringContaining("/tags/19804769/subscribers"));
+	});
+
+	it("should apply source-footer tag for footer source", async () => {
+		await subscribeToNewsletter({ email: "tag-test@example.com", source: "footer" });
+
+		const tagCalls = mockFetchLocal.mock.calls.filter(
+			(c) => typeof c[0] === "string" && (c[0] as string).includes("/tags/")
+		);
+		const tagUrls = tagCalls.map((c) => c[0] as string);
+		expect(tagUrls).toContainEqual(expect.stringContaining("/tags/19804767/subscribers"));
+	});
+});
+
+describe("Turnstile exemption for server-action callers", () => {
+	it("should NOT require Turnstile for stage-fit-quiz-v2 source in production", async () => {
+		const mockFetchTurnstile = vi.fn<typeof globalThis.fetch>();
+		mockFetchTurnstile.mockResolvedValue({
+			ok: true,
+			json: () =>
+				Promise.resolve({
+					subscriber: { id: 1, created_at: "2026-01-01", updated_at: "2026-01-01" },
+				}),
+		} as Response);
+		await __setDependencies({
+			fetch: mockFetchTurnstile,
+			verifyTurnstile: vi.fn().mockResolvedValue(true),
+		});
+
+		mockGetEnv.mockResolvedValueOnce({
+			KIT_API_KEY: "kit-test-key",
+			NODE_ENV: "production",
+			TURNSTILE_SECRET_KEY: "ts-key",
+		});
+
+		const result = await subscribeToNewsletter({
+			email: "test@example.com",
+			source: "stage-fit-quiz-v2",
+			customFields: { stagefit_zone: "over-built" },
+		});
+		expect(result.success).toBe(true);
+
+		await __resetDependencies();
+	});
+
+	it("should still require Turnstile for footer source in production", async () => {
+		await __setDependencies({
+			fetch: vi.fn<typeof globalThis.fetch>(),
+			verifyTurnstile: vi.fn().mockResolvedValue(true),
+		});
+
+		mockGetEnv.mockResolvedValueOnce({
+			KIT_API_KEY: "kit-test-key",
+			NODE_ENV: "production",
+			TURNSTILE_SECRET_KEY: "ts-key",
+		});
+
+		const result = await subscribeToNewsletter({ email: "test@example.com", source: "footer" });
+		expect(result.success).toBe(false);
+		expect(result.error).toContain("Bot check");
+
+		await __resetDependencies();
 	});
 });

--- a/tests/components/tools/stagefit/stagefit-diagnostic.test.tsx
+++ b/tests/components/tools/stagefit/stagefit-diagnostic.test.tsx
@@ -1,7 +1,28 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { StageFitDiagnostic } from "@/components/tools/stagefit/StageFitDiagnostic";
+
+function advanceThroughContext() {
+	fireEvent.click(screen.getByRole("button", { name: /start/i }));
+	fireEvent.click(screen.getByText(/^Technical founder or CTO$/));
+	fireEvent.click(screen.getByText(/B2B SMB/i));
+	fireEvent.click(screen.getByText(/Pre-revenue/i));
+	fireEvent.click(screen.getByText(/No specific goal/i));
+	fireEvent.click(screen.getByText(/^None$/));
+	fireEvent.click(screen.getByText(/^Solo$/));
+	fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+}
+
+function answerAllTechQuestions() {
+	for (let i = 0; i < 8; i++) {
+		const continueBtn = screen.queryByRole("button", { name: /continue/i });
+		if (continueBtn) fireEvent.click(continueBtn);
+
+		const buttons = screen.getAllByRole("button");
+		fireEvent.click(buttons[0]);
+	}
+}
 
 describe("StageFitDiagnostic", () => {
 	it("renders intro screen initially", () => {
@@ -18,22 +39,50 @@ describe("StageFitDiagnostic", () => {
 
 	it("completes full flow through to diagnosis", () => {
 		render(<StageFitDiagnostic />);
-		fireEvent.click(screen.getByRole("button", { name: /start/i }));
-
-		fireEvent.click(screen.getByText(/^Technical founder or CTO$/));
-		fireEvent.click(screen.getByText(/B2B SMB/i));
-		fireEvent.click(screen.getByText(/Pre-revenue/i));
-		fireEvent.click(screen.getByText(/No specific goal/i));
-		fireEvent.click(screen.getByText(/^None$/));
-		fireEvent.click(screen.getByText(/^Solo$/));
-
-		fireEvent.click(screen.getByRole("button", { name: /continue/i }));
-
-		const buttons = screen.getAllByRole("button");
-		for (let i = 0; i < buttons.length; i += 4) {
-			fireEvent.click(buttons[i]);
-		}
+		advanceThroughContext();
+		answerAllTechQuestions();
 
 		expect(screen.getByText(/stage-optimized|over-built|under-built/i)).toBeTruthy();
+	});
+
+	it("shows HotTruncate early signal after 3 tech questions", () => {
+		render(<StageFitDiagnostic />);
+		advanceThroughContext();
+
+		for (let i = 0; i < 3; i++) {
+			const buttons = screen.getAllByRole("button");
+			fireEvent.click(buttons[0]);
+		}
+
+		expect(screen.getByText(/early signal/i)).toBeTruthy();
+	});
+
+	it("shows LeadCapture email form on diagnosis screen", () => {
+		render(<StageFitDiagnostic />);
+		advanceThroughContext();
+		answerAllTechQuestions();
+
+		expect(screen.getByLabelText(/email/i)).toBeTruthy();
+		expect(screen.getByRole("button", { name: /unlock/i })).toBeTruthy();
+	});
+
+	it("hides LeadCapture and shows confirmation after email submit", async () => {
+		vi.mock("@/app/actions/stagefit-lead", () => ({
+			submitStageFitLead: vi.fn().mockResolvedValue({ success: true }),
+		}));
+
+		render(<StageFitDiagnostic />);
+		advanceThroughContext();
+		answerAllTechQuestions();
+
+		fireEvent.change(screen.getByLabelText(/email/i), {
+			target: { value: "test@example.com" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: /unlock/i }));
+
+		await vi.waitFor(() => {
+			expect(screen.queryByLabelText(/email/i)).toBeNull();
+			expect(screen.getByText(/check your inbox/i)).toBeTruthy();
+		});
 	});
 });

--- a/tests/components/tools/stagefit/tech-questions.test.tsx
+++ b/tests/components/tools/stagefit/tech-questions.test.tsx
@@ -3,22 +3,59 @@ import { describe, expect, it, vi } from "vitest";
 
 import { TechQuestions } from "@/components/tools/stagefit/phases/TechQuestions";
 
+import type { TechBaseline } from "@/data/saas-stagefit/baseline-matrix";
+
+const STAGE_0_BASELINE: TechBaseline = {
+	architecture: 1,
+	database: 1,
+	cicd: 1,
+	observability: 1,
+	security: 1,
+	team: 1,
+	performance: 1,
+	data: 1,
+};
+
 describe("TechQuestions", () => {
-	it("renders all 8 tech questions as accordion items", () => {
+	it("renders the first tech question on mount", () => {
 		render(<TechQuestions persona="cto" onComplete={() => {}} />);
 		expect(screen.getByText(/service architecture/i)).toBeTruthy();
-		expect(screen.getByText(/database model/i)).toBeTruthy();
+		expect(screen.getAllByRole("button")).toHaveLength(4);
 	});
 
 	it("calls onComplete with all 8 answers after selecting one option per question", () => {
 		const onComplete = vi.fn();
 		render(<TechQuestions persona="cto" onComplete={onComplete} />);
-		const buttons = screen.getAllByRole("button");
-		for (let i = 0; i < buttons.length; i += 4) {
-			fireEvent.click(buttons[i]);
+		for (let i = 0; i < 8; i++) {
+			const buttons = screen.getAllByRole("button");
+			fireEvent.click(buttons[0]);
 		}
 		expect(onComplete).toHaveBeenCalledTimes(1);
 		const answers = onComplete.mock.calls[0][0] as Record<string, number>;
 		expect(Object.keys(answers)).toHaveLength(8);
+	});
+
+	it("displays question counter and category label", () => {
+		render(<TechQuestions persona="cto" onComplete={() => {}} />);
+		expect(screen.getByText("7 of 14")).toBeTruthy();
+		expect(screen.getByText("Architecture")).toBeTruthy();
+	});
+
+	it("shows one question at a time instead of all 8", () => {
+		render(<TechQuestions persona="cto" onComplete={() => {}} />);
+		const archQuestion = screen.getByText(/service architecture/i);
+		expect(archQuestion).toBeTruthy();
+		expect(screen.queryByText(/database model/i)).toBeNull();
+	});
+
+	it("shows HotTruncate early signal after 3 answers when baseline provided", () => {
+		render(<TechQuestions persona="cto" onComplete={() => {}} baseline={STAGE_0_BASELINE} />);
+
+		for (let i = 0; i < 3; i++) {
+			const buttons = screen.getAllByRole("button");
+			fireEvent.click(buttons[0]);
+		}
+
+		expect(screen.getByText(/early signal/i)).toBeTruthy();
 	});
 });


### PR DESCRIPTION
## **User description**
## Summary
- Wire LeadCapture + HotTruncate into StageFitDiagnostic orchestrator (components existed but weren't rendered)
- Apply all 5 Kit tags via parallel API calls (was only applying architect-brief)
- Exempt stage-fit-quiz-v2 from Turnstile (server action is already server-side validated + rate-limited)
- Convert TechQuestions from all-at-once dump to one-at-a-time pagination with progress bar, category label, and spring animations
- Style DiagnosisScreen with design system tokens

## Test plan
- [x] 1954 tests pass, 0 failures
- [x] Build clean (0 errors)
- [x] Visual verification via Playwright — full quiz flow through intro → context → interstitial → tech (one-at-a-time) → HotTruncate → diagnosis → LeadCapture
- [ ] Verify on production after deploy: quiz shows one question at a time
- [ ] Verify LeadCapture submits to Kit and tags are applied
- [ ] Verify Turnstile is not required for quiz submissions

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Show StageFit results one question at a time, add lead capture, and send the right newsletter tags**

### What Changed
- The tech section now shows one question at a time with a progress indicator and category label instead of displaying all questions at once
- An early “HotTruncate” signal now appears after three tech answers when enough baseline data is available
- The diagnosis screen now includes a lead capture form and shows a confirmation message after email submission
- Newsletter signups now apply the matching source tag, the StageFit lead tag, and the architect brief tag together
- StageFit quiz submissions no longer require Turnstile in the server-side flow, while other sources still do

### Impact
`✅ Shorter StageFit quiz flow`
`✅ Earlier lead capture after diagnosis`
`✅ More complete newsletter tagging`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Wire lead capture, Kit tags, and Turnstile exemption into StageFit diagnostic
> - After diagnosis, [StageFitDiagnostic](https://github.com/LecoMV/alexmayhew.dev/pull/103/files#diff-1aa3edba895f7a3e8d82a36a31b699d2ce720db4ea59781e9a489a20facbb0c2) renders a `LeadCapture` form; on successful submission it hides the form and shows a confirmation message.
> - [TechQuestions](https://github.com/LecoMV/alexmayhew.dev/pull/103/files#diff-3a1f1f0e81b315d507431fc2ed5a0ee10d792039af1c54c14870b99700f57287) now presents one animated question at a time with a progress bar and category label; after 3 answers it shows a `HotTruncate` early signal when a stage baseline is provided.
> - [newsletter.ts](https://github.com/LecoMV/alexmayhew.dev/pull/103/files#diff-f20f9ece041404afbfe91bee593cc24d5b6833042cb02ac648c91eeab11a4cb9) introduces a `TAG_IDS` map and applies multiple Kit tags per subscription: always `architect-brief`, a source-specific tag when matched, and `stagefit-lead` when `stagefit_zone` is present in custom fields.
> - The `stage-fit-quiz-v2` source is added to `TURNSTILE_EXEMPT_SOURCES`, skipping Turnstile verification in production for quiz submissions.
> - Behavioral Change: `subscribeToNewsletter` now fires multiple concurrent tag API calls instead of one, and skips Turnstile for the exempt source even in production.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 84335c8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * StageFit diagnostic tool now captures user email after diagnosis completion
  * Tech questions presented as step-by-step quiz with progress tracking and early signal messages
  * Newsletter signup enhanced to support multiple tag applications
  * Bot-check enforcement now varies by request source, bypassing verification for certain sources

* **Style**
  * Improved styling and layout of diagnosis screens with better typography and spacing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LecoMV/alexmayhew.dev/pull/103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->