### PR TITLE
feat(newsletter): welcome sequence enrollment via Kit sequences API

### DIFF
--- a/src/app/actions/newsletter.ts
+++ b/src/app/actions/newsletter.ts
@@ -41,6 +41,7 @@ const SOURCE_TAG_MAP: Record<string, string> = {
 };
 
 const TURNSTILE_EXEMPT_SOURCES = new Set(["stage-fit-quiz-v2"]);
+const WELCOME_SEQUENCE_ID = 2770667;
 
 const newsletterSchema = z.object({
 	email: z.string().email("Please enter a valid email address"),
@@ -154,8 +155,8 @@ export async function subscribeToNewsletter(data: unknown): Promise<NewsletterFo
 			if (sourceTag && TAG_IDS[sourceTag]) tagIdsToApply.push(TAG_IDS[sourceTag]);
 			if (customFields?.stagefit_zone) tagIdsToApply.push(TAG_IDS["stagefit-lead"]);
 
-			await Promise.all(
-				tagIdsToApply.map((tagId) =>
+			const postSubscribeCalls = [
+				...tagIdsToApply.map((tagId) =>
 					dependencies
 						.fetch(`https://api.kit.com/v4/tags/${tagId}/subscribers`, {
 							method: "POST",
@@ -163,8 +164,17 @@ export async function subscribeToNewsletter(data: unknown): Promise<NewsletterFo
 							body: JSON.stringify({ email_address: email }),
 						})
 						.catch(() => {})
-				)
-			);
+				),
+				dependencies
+					.fetch(`https://api.kit.com/v4/sequences/${WELCOME_SEQUENCE_ID}/subscribers`, {
+						method: "POST",
+						headers: { "X-Kit-Api-Key": apiKey, "Content-Type": "application/json" },
+						body: JSON.stringify({ email_address: email }),
+					})
+					.catch(() => {}),
+			];
+
+			await Promise.all(postSubscribeCalls);
 
 			return { success: true, existingSubscriber: isExisting };
 		}

--- a/tests/actions/newsletter.test.ts
+++ b/tests/actions/newsletter.test.ts
@@ -230,6 +230,21 @@ describe("subscribeToNewsletter", () => {
 			expect(tagCalls[0][0]).toContain("/subscribers");
 		});
 
+		it("should enroll subscriber in welcome sequence via separate API call", async () => {
+			await subscribeToNewsletter({ email: "seq@example.com", source: "footer" });
+
+			const seqCalls = mockFetch.mock.calls.filter(
+				(c) => typeof c[0] === "string" && (c[0] as string).includes("/sequences/")
+			);
+			expect(seqCalls.length).toBe(1);
+			expect(seqCalls[0][0]).toContain("/sequences/2770667/subscribers");
+			const seqBody = JSON.parse((seqCalls[0][1] as RequestInit).body as string) as Record<
+				string,
+				unknown
+			>;
+			expect(seqBody.email_address).toBe("seq@example.com");
+		});
+
 		it("should include AbortSignal with 8-second timeout", async () => {
 			await subscribeToNewsletter({ email: "timeout@example.com", source: "website" });
 


### PR DESCRIPTION
## **User description**
## Summary
- Enroll new subscribers in welcome sequence (id 2770667) via documented `POST /v4/sequences/{id}/subscribers` endpoint
- Enrollment happens in parallel with tag application after subscriber upsert
- Three-brain reviewed: Codex caught that `sequence_ids` body param is undocumented — fixed to use separate API call per Kit v4 docs

Also done this session (not in this PR):
- Published 3 welcome sequence emails in Kit (Day 0, Day 3, Day 7)
- Fixed broadcast #1 code block rendering (backticks → HTML pre)
- Deleted 6 stale Worker secrets (BEEHIIV_*, LISTMONK_*, BUTTONDOWN_*)

## Test plan
- [x] 1955 tests pass, build clean
- [x] Test verifies separate `/sequences/2770667/subscribers` call with correct email
- [ ] Verify subscription + sequence enrollment end-to-end after deploy

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enroll new newsletter subscribers in Kit welcome sequence 2770667
> Adds a POST call to the Kit `/v4/sequences/{WELCOME_SEQUENCE_ID}/subscribers` endpoint in `subscribeToNewsletter`, running in parallel with existing tag application via `Promise.all`. The sequence ID is defined as the constant `WELCOME_SEQUENCE_ID = 2770667` in [newsletter.ts](https://github.com/LecoMV/alexmayhew.dev/pull/106/files#diff-f20f9ece041404afbfe91bee593cc24d5b6833042cb02ac648c91eeab11a4cb9).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 694aa6d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->


___

## **CodeAnt-AI Description**
Add new newsletter subscribers to the welcome sequence

### What Changed
- New subscribers are now enrolled in the welcome sequence right after signup
- Welcome sequence enrollment happens alongside tag application, so subscribers receive both actions after a successful subscribe
- A test now checks that the welcome sequence is sent through its own API call with the subscriber email

### Impact
`✅ Automatic welcome emails for new subscribers`
`✅ Fewer missed sequence enrollments`
`✅ Clearer subscriber onboarding`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
